### PR TITLE
Zero globals before each init() run

### DIFF
--- a/testdata/scripts/recursive_lowlevel.txt
+++ b/testdata/scripts/recursive_lowlevel.txt
@@ -45,7 +45,6 @@ func init() {
 
 	signal.Notify(sign, os.Interrupt)
 
-	// TODO: fix this; the global isn't being zeroed by init.
-	// var b bool
-	// flagSet.BoolVar(&b, "i", false, "")
+	var b bool
+	flagSet.BoolVar(&b, "i", false, "")
 }


### PR DESCRIPTION
This caused the flags package to fail because it checks that the flag
has not already been initialized. Now we simply zero all globals every
time so that init() sees the expected initial heap state.